### PR TITLE
Added logging for all module and the main process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ### Project related ###
 
+/log
 /modules
 /dist
 

--- a/app/logDirectory.js
+++ b/app/logDirectory.js
@@ -1,0 +1,10 @@
+const fs = require('fs')
+const {join} = require('path')
+
+const logPath = join(__dirname, '..', 'log')
+
+if (!fs.existsSync(logPath)) {
+  fs.mkdirSync(logPath)
+}
+
+module.exports = logPath

--- a/app/logDirectory.js
+++ b/app/logDirectory.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
-const {join} = require('path')
+const {resolve} = require('path')
 
-const logPath = join(__dirname, '..', 'log')
+const logPath = resolve(__dirname, '..', 'log')
 
 if (!fs.existsSync(logPath)) {
   fs.mkdirSync(logPath)

--- a/app/main.js
+++ b/app/main.js
@@ -8,7 +8,10 @@ const window = require('./window')
 
 const {Server} = require('./server')
 
-function getIcon() {
+const logPath = require('./logDirectory')
+const rotate = require('rotating-file-stream')
+
+function getIcon () {
   return path.join(__dirname, 'images', 'icon.png')
 }
 
@@ -31,6 +34,13 @@ if (isSecondInstance) {
   app.quit()
 } else {
   app.on('ready', () => {
+    var stream = rotate('launcher', {
+      size: '10M',
+      interval: '1d',
+      path: logPath
+    })
+    process.stdout.pipe(stream)
+    process.stderr.pipe(stream)
     server = new Server(path.join(process.cwd(), 'modules.yml'))
     exports.server = server
     server.start()

--- a/app/module-types/node.js
+++ b/app/module-types/node.js
@@ -2,7 +2,7 @@
 
 const Promise = require('bluebird')
 const request = require('request')
-const {join} = require('path')
+const {join, resolve} = require('path')
 const tar = require('tar-fs')
 const {exec, fork, spawn} = require('child_process')
 const {createGunzip} = require('zlib')
@@ -38,7 +38,7 @@ exports.NodeModule = class {
 
   start () {
     if (this.script) {
-      const moduleLogPath = join(logPath, this.name)
+      const moduleLogPath = resolve(logPath, this.name)
       if (!fs.existsSync(moduleLogPath)) {
         fs.mkdirSync(moduleLogPath)
       }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "js-yaml": "^3.9.0",
     "opn": "^5.1.0",
     "request": "^2.81.0",
+    "rotating-file-stream": "^1.3.2",
     "tar-fs": "^1.15.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1862,11 +1862,21 @@ restore-cursor@^2.0.0:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
 
-rimraf@^2.2.8, rimraf@^2.6.1:
+rimraf@^2.2.8:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
     glob "^7.0.5"
+
+rimraf@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
+  dependencies:
+    glob "^7.0.5"
+
+rotating-file-stream@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/rotating-file-stream/-/rotating-file-stream-1.3.2.tgz#73cbfd443124a35ddbb4fb9f8ea8c23565c25712"
 
 run-async@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
This works by directing the stderr and stdout of all forked modules as well as the main process to rotating files generated by [rotating-file-stream](https://www.npmjs.com/package/rotating-file-stream) under the log directory. This means that the scoring module logs twice- it logs once on its own, and another when the launcher logs its output.
This means modules and the launcher will no longer log to the command line; However I see this as a feature as it enables you to selectively choose the outputs you want to see by using `tail -f` on just the log file for the module that interests you.