### PR TITLE
 Fixed app acting abnormally on quiting and closing windows

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -8,7 +8,7 @@ const window = require('./window')
 
 const {Server} = require('./server')
 
-function getIcon() {
+function getIcon () {
   return path.join(__dirname, 'images', 'icon.png')
 }
 
@@ -48,7 +48,12 @@ if (isSecondInstance) {
 
   })
 
+  app.on('window-all-closed', event => { // this prevents the app from trying to quit when you close the main window
+    event.preventDefault()
+  })
+
   app.on('before-quit', () => {
+    window.mainWindow.destroy() // prevents it from showing any closing dialog
     server.close()
   })
 }

--- a/app/server.js
+++ b/app/server.js
@@ -29,7 +29,9 @@ exports.Server = class {
 
   close () {
     return this.stopFunctionsPromise
-      .each(stop => stop())
+      .each(stop => {
+        stop()
+      })
   }
 
   getModules () {

--- a/app/window.js
+++ b/app/window.js
@@ -26,17 +26,19 @@ exports.buildMainWindow = () => {
     slashes: true
   }))
 
-
-  // Emitted when the window is closed.
+  // Emitted after the window is closed, in any way shape or form
   exports.mainWindow.on('closed', function () {
-    // Showing message so people will know its in system tray
-    var dialog = electron.dialog
-    dialog.showMessageBox({message: 'This window is still available in the tray'})
-
     // Dereference the window object, usually you would store windows
     // in an array if your app supports multi windows, this is the time
     // when you should delete the corresponding element.
     exports.mainWindow = null
+  })
+
+  // Emitted before the window is closed by the user or using the the close() function
+  exports.mainWindow.on('close', () => {
+    // Showing message so people will know its in system tray
+    var dialog = electron.dialog
+    dialog.showMessageBox({message: 'This window is still available in the tray'})
   })
 }
 
@@ -65,6 +67,6 @@ exports.buildMainWindow = () => {
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.
 
-function getIcon() {
+function getIcon () {
   return path.join(__dirname, 'images', 'icon.png')
 }


### PR DESCRIPTION
1. Fixed the server not terminating all modules correctly
2. Fixed app showing the "This window is available in tray" dialog when quitting
3. Fixed app quitting when the main window is closed (in conjunction with point 1 this makes everything look fine, because the app tries to quit on window close and fails, and then when you start it again to reveal the mainWindow it builds the main window and fails to start all the modules because the ports are taken, which looks fine to you but actually this mainWindow is from a whole other process independent from your original)