### PR TITLE
Replaced usage of "opn" with electron.shell

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -21,7 +21,7 @@
     }
   </style>
   <script>
-    const opn = require('opn');
+    const {shell} = require('electron');
     const ip = require('ip');
     const path = require('path');
     const url = require('url');
@@ -63,19 +63,19 @@
       <th style="text-align:right;"><img src="images/FLL-full-triangle_with-new-logo.jpg" style="height:100px;" /></th>
     </tr>
     <tr>
-      <td><a id="Management" onclick="opn(addressAdmin)">Management</a></td>
+      <td><a id="Management" onclick="shell.openExternal(addressAdmin)">Management</a></td>
     </tr>
     <tr>
-      <td><a id="ScoreEntry" onclick="opn(addressScoring)">Score Entry</a></td>
-      <td><a id="scoreAtag" onclick="opn(addressScoring)"></a> from other computers</td>
+      <td><a id="ScoreEntry" onclick="shell.openExternal(addressScoring)">Score Entry</a></td>
+      <td><a id="scoreAtag" onclick="shell.openExternal(addressScoring)"></a> from other computers</td>
     </tr>
     <tr>
-      <td><a id="Display" onclick="opn(addressDisplay)">Team Score Display</a></td>
-      <td><a id="displayAtag" onclick="opn(addressDisplay)"></a>from other computers</td>
+      <td><a id="Display" onclick="shell.openExternal(addressDisplay)">Team Score Display</a></td>
+      <td><a id="displayAtag" onclick="shell.openExternal(addressDisplay)"></a>from other computers</td>
     </tr>
     <tr>
-      <td><a id="Clock" onclick="opn(addressClock)">Robot Game Timer</a></td>
-      <td><a id="clockAtag" onclick="opn(addressClock)"></a> from other computers</td>
+      <td><a id="Clock" onclick="shell.openExternal(addressClock)">Robot Game Timer</a></td>
+      <td><a id="clockAtag" onclick="shell.openExternal(addressClock)"></a> from other computers</td>
     </tr>
 
     <tr>

--- a/app/menu.js
+++ b/app/menu.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const {Menu} = require('electron')
-const opn = require('opn')
+const {shell} = require('electron')
 const ip = require('ip')
 const clipboard = require('clipboardy')
 const window = require('./window')
@@ -14,7 +14,7 @@ exports.buildAppMenu = modulesPromise => {
           label: module.name,
           type: 'normal',
           click: () => {
-            opn(module.link)
+            shell.openExternal(module.link)
           }
         })
       } else {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "electron-is-dev": "^0.3.0",
     "ip": "^1.1.5",
     "js-yaml": "^3.9.0",
-    "opn": "^5.1.0",
     "request": "^2.81.0",
     "rimraf": "^2.6.2",
     "rotating-file-stream": "^1.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,10 +1192,6 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
-is-wsl@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
-
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -1518,12 +1514,6 @@ onetime@^2.0.0:
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
   dependencies:
     mimic-fn "^1.0.0"
-
-opn@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/opn/-/opn-5.1.0.tgz#72ce2306a17dbea58ff1041853352b4a8fc77519"
-  dependencies:
-    is-wsl "^1.1.0"
 
 optionator@^0.8.2:
   version "0.8.2"


### PR DESCRIPTION
opn has a known issue [preventing it from working correctly with electron](https://github.com/sindresorhus/opn/issues/57). The solution to said issue according to opn's maintainers is to use electron.shell methods instead.