### PR TITLE
Checking if network interface exist before trying to get his ip

### DIFF
--- a/src/main/network.js
+++ b/src/main/network.js
@@ -10,7 +10,9 @@ const networkInterfaces = Object.entries(os.networkInterfaces())
 exports.networkInterfaces = () => networkInterfaces
 
 exports.getIp = networkInterface => {
-  networkInterface = networkInterface || Object.keys(networkInterfaces)[0]
-
+  networkInterface = networkInterfaces[networkInterface] ? networkInterface : Object.keys(networkInterfaces)[0]
+  if (!networkInterface) {
+    return '127.0.0.1'
+  }
   return networkInterfaces[networkInterface][0].address
 }


### PR DESCRIPTION
I had a problem with detecting the network interfaces. 
this method was not working if a name of a network interface that does not exists was passed to it